### PR TITLE
ignore changes to private_dns_zone_group

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -45,7 +45,8 @@ resource "azurerm_private_endpoint" "kv_pe" {
 
   lifecycle {
     ignore_changes = [
-      tags
+      tags,
+      private_dns_zone_group,
     ]
   }
 }


### PR DESCRIPTION
Terraform need to ignore changes to this value to support policy that creates dns zone groups for private endpoints

## Changelog entry
```
ignore changes to private_dns_zone_group in private endpoint resources
```